### PR TITLE
Release 0.1.1: Conditionally emit link section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## [Unreleased] - YYYY-MM-DD
+## [0.1.1] - 2020-06-18
 
-## Changed
+### Changed
 
-Conditionally specificy `link_section` on FlexSPI configuration blocks. We only specify the link section when compiling for ARM.
+Conditionally specificy `link_section` on FlexSPI configuration blocks. We only emit the link section when compiling for ARM.
 
 ## [0.1.0] - 2020-04-07
 
 First release
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/imxrt-rs/imxrt-boot-gen/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [Unreleased] - YYYY-MM-DD
+
+## Changed
+
+Conditionally specificy `link_section` on FlexSPI configuration blocks. We only specify the link section when compiling for ARM.
+
+## [0.1.0] - 2020-04-07
+
+First release
+
+[Unreleased]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/imxrt-rs/imxrt-boot-gen/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ include!(concat!(env!("OUT_DIR"), "/fcb.rs"));
 Your crate now exports a FCB that resembles
 
 ```rust
-#[link_section = ".fcb"]
+#[cfg_attr(target_arch = "arm", link_section = ".fcb")]
 #[no_mangle]
 pub static FLEXSPI_CONFIGURATION_BLOCK: [u8; 512] = [
     0x46, // 0x000 Tag 'FCFB'
@@ -56,7 +56,7 @@ You may now link that crate into another executable. Make sure that you place th
 
 ## ABI
 
-The generated FCB has the symbol `FLEXSPI_CONFIGURATION_BLOCK`. The symbol is not mangled. The memory is an array of 512 `u8`s. It has a link section of `".fcb"`. The ABI ensures compatibility with both Rust and C. By building a C static library from your Rust crate, you can link the FCB into other C applications that target the iMXRT processor family.
+The generated FCB has the symbol `FLEXSPI_CONFIGURATION_BLOCK`. The symbol is not mangled. The memory is an array of 512 `u8`s. It has a link section of `".fcb"` when built for ARM systems. The ABI ensures compatibility with both Rust and C. By building a C static library from your Rust crate, you can link the FCB into other C applications that target the iMXRT processor family.
 
 ## Supported Processors
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,9 @@
 //! # ABI
 //!
 //! The output is a single, 512-byte `u8` array, called `FLEXSPI_CONFIGURATION_BLOCK`.
-//! The name is not mangled. It may be referenced in a linker script by its section,
-//! `".fcb"`. Given the ABI guarantees, the FCB should be usable from both Rust and C.
+//! The name is not mangled. When building for ARM platforms, it may be referenced
+//! in a linker script by its section, `".fcb"`. Given the ABI guarantees, the FCB
+//! should be usable from both Rust and C.
 
 mod flexspi_lut;
 pub mod serial_flash;

--- a/src/serial_flash/fcb.rs
+++ b/src/serial_flash/fcb.rs
@@ -110,7 +110,7 @@ impl fmt::Display for FCB {
         writeln!(
             f,
             r#"
-#[link_section = ".fcb"]
+#[cfg_attr(target_arch = "arm", link_section = ".fcb")]
 #[no_mangle]
 pub static FLEXSPI_CONFIGURATION_BLOCK: [u8; 512] = ["#,
         )?;


### PR DESCRIPTION
Some platforms (macOS) have restrictions on link section names. If you try to compile unit tests that run on your host, and this crate is pulled-in through the dependency chain, you'll hit an error. By conditionally emitting a link section -- only for the targets for which this crate actually matters -- you can build your unit tests locally.

I came upon this when working on the [imxrt-uart-log](https://github.com/imxrt-rs/imxrt-uart-log) crate (see [here](https://github.com/imxrt-rs/imxrt-uart-log/blob/817f76bdaa789e474e377bb6b30812959e576fe9/examples/t4_blocking.rs#L13)). The conditional link section is a quality-of-life helper, so that users don't need to add their own `#[cfg(target_arch = "arm")]` guards if they're including an `extern crate m_fcb` but building for their host.