### PR TITLE
Add 1170 support, and 1170EVK and 1010EVK FCBs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        feature: ["imxrt1010", "imxrt1060", "imxrt1064"]
+        feature: ["imxrt1010", "imxrt1060", "imxrt1064", "imxrt1170"]
 
     runs-on: ubuntu-latest
 
@@ -20,7 +20,7 @@ jobs:
   clippy:
     strategy:
       matrix:
-        feature: ["imxrt1010", "imxrt1060"]
+        feature: ["imxrt1010", "imxrt1060", "imxrt1170"]
       
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build (${{ matrix.feature }})
-      run: cargo build --verbose --features ${{ matrix.feature }}
+      run: cargo build --package=imxrt-boot-gen --verbose --features=${{ matrix.feature }}
     - name: Run tests (${{ matrix.feature }})
-      run: cargo test --verbose --features ${{ matrix.feature }}
+      run: cargo test --package=imxrt-boot-gen --verbose --features=${{ matrix.feature }}
   
   clippy:
     strategy:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features ${{ matrix.feature }} -- -D warnings
+          args: --package=imxrt-boot-gen --features=${{ matrix.feature }} -- -D warnings
           name: Run clippy (${{ matrix.feature }})
 
   format:
@@ -43,3 +43,24 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  fcbs:
+    strategy:
+      matrix:
+        fcb: ["imxrt1010evk-fcb", "imxrt1170evk-fcb"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: thumbv7em-none-eabihf
+    - name: Build for an embedded target
+      run: cargo build --package=${{ matrix.fcb }} --verbose --target=thumbv7em-none-eabihf
+    - name: Build and run tests on the host
+      run: cargo test --package=${{ matrix.fcb }} --verbose
+    - uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --package=${{ matrix.fcb }} -- -D warnings
+        name: Lint the package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
 **BREAKING** Update Rust edition to 2021.
 
 Add support for the 1170 family.
+
+## [0.2.1] - 2022-11-21
 
 Fix the `ipCmdSerialClkFreq` field width in the serial NOR flash configuration
 block.
@@ -136,6 +138,7 @@ static SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
 
 First release
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/imxrt-rs/imxrt-boot-gen/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.0] - YYYY-MM-DD
+## [0.2.0] - 2020-12-26
 
 **BREAKING** The 0.2 release introduces a `const` API to replace the build-time
 interface. We do not generate data structures in a build script, then write them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+Fix the `ipCmdSerialClkFreq` field width in the serial NOR flash configuration
+block.
+
 ## [0.2.0] - 2020-12-26
 
 **BREAKING** The 0.2 release introduces a `const` API to replace the build-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+**BREAKING** Update Rust edition to 2021.
+
 Add support for the 1170 family.
 
 Fix the `ipCmdSerialClkFreq` field width in the serial NOR flash configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+This document tracks changes to the `imxrt-boot-gen` package and all other
+packages maintained within this repository.
+
 ## [Unreleased]
+
+## [0.3.0] - 2022-11-21
 
 **BREAKING** Update Rust edition to 2021.
 
 Add support for the 1170 family.
+
+Publish 0.1 FCBs for NXP's IMXRT1010EVK and IMXRT1170EVK.
 
 ## [0.2.1] - 2022-11-21
 
@@ -139,6 +146,7 @@ static SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
 First release
 
 [Unreleased]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.2.1...HEAD
+[0.3.0]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/imxrt-rs/imxrt-boot-gen/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/imxrt-rs/imxrt-boot-gen/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Add support for the 1170 family.
+
 Fix the `ipCmdSerialClkFreq` field width in the serial NOR flash configuration
 block.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imxrt-boot-gen"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ keywords = [
     "imxrt",
 ]
 
-[dependencies]
-
 [features]
 imxrt1010 = []
 imxrt1060 = []
@@ -30,3 +28,8 @@ imxrt1170 = []
 [package.metadata.docs.rs]
 features = ["imxrt1060"]
 default-target = "thumbv7em-none-eabihf"
+
+[workspace]
+members = [
+    "fcbs/*",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
 name = "imxrt-boot-gen"
 version = "0.2.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+description = """
+Generate data structures for booting iMXRT processors.
+"""
+
+[workspace.package]
 authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imxrt-rs/imxrt-boot-gen"
-description = """
-Generate data structures for booting iMXRT processors.
-"""
 categories = [
     "embedded",
     "hardware-support",
@@ -17,6 +25,7 @@ keywords = [
     "arm",
     "cortex-m",
     "imxrt",
+    "nxp",
 ]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ keywords = [
 imxrt1010 = []
 imxrt1060 = []
 imxrt1064 = []
+imxrt1170 = []
 
 [package.metadata.docs.rs]
 features = ["imxrt1060"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ Generate data structures for booting iMXRT processors.
 
 [workspace.package]
 authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imxrt-rs/imxrt-boot-gen"
 categories = [

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The supported features are listed below.
 - `"imxrt1010"`
 - `"imxrt1060"`
 - `"imxrt1064"`
+- `"imxrt1170"`
 
 ### License
 

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@
 use std::env;
 
 // Keep this in sync with the available features
-static SUPPORTED_FEATURES: &[&str] = &["imxrt1010", "imxrt1060", "imxrt1064"];
+static SUPPORTED_FEATURES: &[&str] = &["imxrt1010", "imxrt1060", "imxrt1064", "imxrt1170"];
 
 fn main() {
     let feature_count = SUPPORTED_FEATURES

--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,12 @@ use std::env;
 static SUPPORTED_FEATURES: &[&str] = &["imxrt1010", "imxrt1060", "imxrt1064", "imxrt1170"];
 
 fn main() {
-    let feature_count = SUPPORTED_FEATURES
-        .iter()
-        .cloned()
-        .map(str::to_uppercase)
-        .map(|feature| format!("CARGO_FEATURE_{}", feature))
-        .map(|cargo_feature| env::var(cargo_feature).is_ok() as i32)
-        .sum();
+    let features: Vec<_> = env::vars()
+        .map(|(key, _)| key)
+        .flat_map(|key| key.strip_prefix("CARGO_FEATURE_").map(str::to_lowercase))
+        .collect();
+
+    let feature_count = features.len();
 
     if 0 == feature_count {
         panic!(
@@ -22,7 +21,8 @@ fn main() {
         );
     } else if feature_count > 1 {
         panic!(
-            "Too many features selected! Select one feature from the feature list: {}",
+            "Too many features selected! Detected features {:?}. Select one feature from the feature list: {}",
+            features,
             SUPPORTED_FEATURES.join(" | ")
         );
     }

--- a/fcbs/imxrt1010evk/Cargo.toml
+++ b/fcbs/imxrt1010evk/Cargo.toml
@@ -7,9 +7,10 @@ license.workspace = true
 repository.workspace = true
 categories.workspace = true
 keywords.workspace = true
+description = "FlexSPI configuration block for NXP's IMXRT1010EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.2"
+version = "0.3"
 path = "../.."
 features = ["imxrt1010"]
 

--- a/fcbs/imxrt1010evk/Cargo.toml
+++ b/fcbs/imxrt1010evk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "imxrt1010evk-fcb"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.imxrt-boot-gen]
+version = "0.2"
+path = "../.."
+features = ["imxrt1010"]
+
+[lib]
+path = "lib.rs"

--- a/fcbs/imxrt1010evk/Cargo.toml
+++ b/fcbs/imxrt1010evk/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "imxrt1010evk-fcb"
 version = "0.1.0"
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies.imxrt-boot-gen]
 version = "0.2"

--- a/fcbs/imxrt1010evk/lib.rs
+++ b/fcbs/imxrt1010evk/lib.rs
@@ -1,0 +1,69 @@
+//! FlexSPI configuration block (FCB) for the iMXRT1010EVK.
+//!
+//! This FCB is compatible with the Adesto QuadSPI flash storage found on the
+//! iMXRT1010EVK.
+#![no_std]
+
+pub use nor::ConfigurationBlock;
+
+use imxrt_boot_gen::flexspi::{self, opcodes::sdr::*, *};
+use imxrt_boot_gen::serial_flash::*;
+
+const DENSITY_BITS: u32 = 128 * 1024 * 1024;
+const DENSITY_BYTES: u32 = DENSITY_BITS / 8;
+
+const SEQ_READ: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0xEB))
+    .instr(Instr::new(RADDR, Pads::Four, 0x18))
+    .instr(Instr::new(DUMMY, Pads::Four, 0x06))
+    .instr(Instr::new(READ, Pads::Four, 0x04))
+    .build();
+const SEQ_READ_STATUS: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x05))
+    .instr(Instr::new(READ, Pads::One, 0x04))
+    .build();
+const SEQ_WRITE_ENABLE: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x06))
+    .build();
+const SEQ_ERASE_SECTOR: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x20))
+    .instr(Instr::new(RADDR, Pads::One, 0x18))
+    .build();
+const SEQ_PAGE_PROGRAM: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x02))
+    .instr(Instr::new(RADDR, Pads::One, 0x18))
+    .instr(Instr::new(WRITE, Pads::One, 0x04))
+    .build();
+const SEQ_CHIP_ERASE: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x60))
+    .build();
+
+const LUT: LookupTable = LookupTable::new()
+    .command(Command::Read, SEQ_READ)
+    .command(Command::ReadStatus, SEQ_READ_STATUS)
+    .command(Command::WriteEnable, SEQ_WRITE_ENABLE)
+    .command(Command::EraseSector, SEQ_ERASE_SECTOR)
+    .command(Command::PageProgram, SEQ_PAGE_PROGRAM)
+    .command(Command::ChipErase, SEQ_CHIP_ERASE);
+
+const COMMON_CONFIGURATION_BLOCK: flexspi::ConfigurationBlock =
+    flexspi::ConfigurationBlock::new(LUT)
+        .read_sample_clk_src(ReadSampleClockSource::LoopbackFromDQSPad)
+        .cs_hold_time(0x03)
+        .cs_setup_time(0x03)
+        .column_address_width(ColumnAddressWidth::OtherDevices)
+        .device_mode_configuration(DeviceModeConfiguration::Disabled)
+        .wait_time_cfg_commands(WaitTimeConfigurationCommands::disable())
+        .flash_size(SerialFlashRegion::A1, DENSITY_BYTES)
+        .serial_clk_freq(SerialClockFrequency::MHz120)
+        .serial_flash_pad_type(FlashPadType::Quad);
+
+pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
+    nor::ConfigurationBlock::new(COMMON_CONFIGURATION_BLOCK)
+        .page_size(256)
+        .sector_size(4096)
+        .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30);
+
+#[no_mangle]
+#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;

--- a/fcbs/imxrt1170evk/Cargo.toml
+++ b/fcbs/imxrt1170evk/Cargo.toml
@@ -7,9 +7,10 @@ license.workspace = true
 repository.workspace = true
 categories.workspace = true
 keywords.workspace = true
+description = "FlexSPI configuration block for NXP's IMXRT1170EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.2"
+version = "0.3"
 path = "../.."
 features = ["imxrt1170"]
 

--- a/fcbs/imxrt1170evk/Cargo.toml
+++ b/fcbs/imxrt1170evk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "imxrt1170evk-fcb"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.imxrt-boot-gen]
+version = "0.2"
+path = "../.."
+features = ["imxrt1170"]
+
+[lib]
+path = "lib.rs"

--- a/fcbs/imxrt1170evk/Cargo.toml
+++ b/fcbs/imxrt1170evk/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "imxrt1170evk-fcb"
 version = "0.1.0"
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
 
 [dependencies.imxrt-boot-gen]
 version = "0.2"

--- a/fcbs/imxrt1170evk/lib.rs
+++ b/fcbs/imxrt1170evk/lib.rs
@@ -1,0 +1,115 @@
+//! FlexSPI configuration block (FCB) for the iMXRT1170EVK.
+//!
+//! This FCB is compatible with the IS25WB QuadSPI flash storage found on the
+//! iMXRT1170EVK.
+#![no_std]
+
+pub use nor::ConfigurationBlock;
+
+use imxrt_boot_gen::flexspi::{self, opcodes::sdr::*, *};
+use imxrt_boot_gen::flexspi::{
+    FlashPadType, ReadSampleClockSource, SerialClockFrequency, SerialFlashRegion,
+};
+use imxrt_boot_gen::serial_flash::*;
+
+const SEQ_READ: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0xEB))
+    .instr(Instr::new(RADDR, Pads::Four, 0x18))
+    .instr(Instr::new(DUMMY, Pads::Four, 0x06))
+    .instr(Instr::new(READ, Pads::Four, 0x04))
+    .build();
+const SEQ_READ_STATUS: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x05))
+    .instr(Instr::new(READ, Pads::One, 0x04))
+    .build();
+const SEQ_WRITE_ENABLE: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x06))
+    .build();
+const SEQ_ERASE_SECTOR: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x20))
+    .instr(Instr::new(RADDR, Pads::One, 0x18))
+    .build();
+const SEQ_PAGE_PROGRAM: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x02))
+    .instr(Instr::new(RADDR, Pads::One, 0x18))
+    .instr(Instr::new(WRITE, Pads::One, 0x04))
+    .build();
+const SEQ_CHIP_ERASE: Sequence = SequenceBuilder::new()
+    .instr(Instr::new(CMD, Pads::One, 0x60))
+    .build();
+
+const LUT: LookupTable = LookupTable::new()
+    .command(Command::Read, SEQ_READ)
+    .command(Command::ReadStatus, SEQ_READ_STATUS)
+    .command(Command::WriteEnable, SEQ_WRITE_ENABLE)
+    .command(Command::EraseSector, SEQ_ERASE_SECTOR)
+    .command(Command::PageProgram, SEQ_PAGE_PROGRAM)
+    .command(Command::ChipErase, SEQ_CHIP_ERASE);
+
+const COMMON_CONFIGURATION_BLOCK: flexspi::ConfigurationBlock =
+    flexspi::ConfigurationBlock::new(LUT)
+        .version(Version::new(1, 4, 0))
+        .read_sample_clk_src(ReadSampleClockSource::LoopbackFromDQSPad)
+        .cs_hold_time(3)
+        .cs_setup_time(3)
+        .controller_misc_options(0x10)
+        .serial_flash_pad_type(FlashPadType::Quad)
+        .serial_clk_freq(SerialClockFrequency::MHz133)
+        .flash_size(SerialFlashRegion::A1, 16 * 1024 * 1024);
+
+pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
+    nor::ConfigurationBlock::new(COMMON_CONFIGURATION_BLOCK)
+        .page_size(256)
+        .sector_size(4 * 1024)
+        .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30)
+        .block_size(64 * 1024);
+
+#[no_mangle]
+#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;
+
+#[cfg(test)]
+mod tests {
+    use super::SERIAL_NOR_CONFIGURATION_BLOCK;
+
+    /// Magic numbers extracted from a build of the 1170 EVK's SDK.
+    ///
+    /// The actual configuration has an instruction sequence, 'erase block,'
+    /// at offset 0x100. I I dropped it when coping over the raw values, since
+    /// we don't have support for custom instruction sequences. Erase sector and
+    /// erase chip are both implemented.
+    const EXPECTED: [u32; 128] = [
+        0x46434642, 0x00040156, 0x00000000, 0x01030300, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x10000000, 0x01040700, 0x00000000, 0x00000000, 0x00000001,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xeb04180a, 0x06320426, 0x00000000,
+        0x00000000, 0x05040424, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x06040000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x20041808, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x02041808, 0x04200000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x60040000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00010000, 0x00100000, 0x01000000, 0x00000000, 0x00000100, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000,
+    ];
+
+    #[test]
+    fn imxrt1170evk() {
+        let actual: [u32; 128] = unsafe { core::mem::transmute(SERIAL_NOR_CONFIGURATION_BLOCK) };
+        for (i, (a, e)) in actual.iter().zip(EXPECTED).enumerate() {
+            let offset = i * 4;
+            assert_eq!(
+                a.to_be_bytes(),
+                e.to_le_bytes(),
+                "Offset {offset:#X}\nACTUAL: {actual:?}\nEXPECTED: {EXPECTED:?}"
+            );
+        }
+    }
+}

--- a/src/flexspi.rs
+++ b/src/flexspi.rs
@@ -135,7 +135,7 @@ pub struct ConfigurationBlock {
     controller_misc_options: u32,
     pub(crate) device_type: u8,
     serial_flash_pad_type: u8,
-    serial_clk_freq: u8,
+    serial_clk_freq: SerialClockFrequency,
     lut_custom_seq_enable: u8,
     _reserved5: [u8; 8], // 0x048
     /// A1, A2, B1, B2
@@ -175,7 +175,7 @@ impl ConfigurationBlock {
             controller_misc_options: 0,
             device_type: 0, // Invalid value; must be updated in NOR / NAND configuration block
             serial_flash_pad_type: 1, // Single pad
-            serial_clk_freq: 0, // 30MHz
+            serial_clk_freq: SerialClockFrequency::MHz30, // 30MHz
             lut_custom_seq_enable: 0,
             serial_flash_sizes: [0; 4],
             cs_pad_setting_override: 0,
@@ -281,7 +281,7 @@ impl ConfigurationBlock {
     ///
     /// If not set, this defaults to `SerialClockFrequency::MHz30`.
     pub const fn serial_clk_freq(mut self, serial_clk_freq: SerialClockFrequency) -> Self {
-        self.serial_clk_freq = serial_clk_freq as u8;
+        self.serial_clk_freq = serial_clk_freq;
         self
     }
 

--- a/src/flexspi/fields.rs
+++ b/src/flexspi/fields.rs
@@ -15,6 +15,7 @@ pub enum ReadSampleClockSource {
 pub enum ColumnAddressWidth {
     OtherDevices = 0,
     Hyperflash = 3,
+    // TODO serial NAND flash values 12 and 13 apply to imxrt1170.
 }
 
 /// Sequence parameter for device mode configuration
@@ -97,15 +98,16 @@ pub enum FlashPadType {
 #[repr(u8)]
 pub enum SerialClockFrequency {
     MHz30 = 1,
-    MHz50 = 2,
-    MHz60 = 3,
-    MHz75 = 4,
-    MHz80 = 5,
-    MHz100 = 6,
-    MHz120 = 7,
-    MHz133 = 8,
-    #[cfg(any(feature = "imxrt1060", feature = "imxrt1064"))]
-    MHz166 = 9,
+    MHz50,
+    MHz60,
+    #[cfg(not(feature = "imxrt1170"))]
+    MHz75,
+    MHz80,
+    MHz100,
+    MHz120,
+    MHz133,
+    #[cfg(any(feature = "imxrt1060", feature = "imxrt1064", feature = "imxrt1170"))]
+    MHz166,
 }
 
 /// A FlexSPI serial flash region

--- a/src/serial_flash/nor.rs
+++ b/src/serial_flash/nor.rs
@@ -54,8 +54,8 @@ pub struct ConfigurationBlock {
     mem_cfg: flexspi::ConfigurationBlock,
     page_size: u32,
     sector_size: u32,
-    ip_cmd_serial_clk_freq: u32,
-    _reserved: [u8; 52],
+    ip_cmd_serial_clk_freq: SerialClockFrequency,
+    _reserved: [u8; 55],
 }
 
 impl ConfigurationBlock {
@@ -67,8 +67,8 @@ impl ConfigurationBlock {
             mem_cfg,
             page_size: 0,
             sector_size: 0,
-            ip_cmd_serial_clk_freq: 0,
-            _reserved: [0; 52],
+            ip_cmd_serial_clk_freq: SerialClockFrequency::NoChange,
+            _reserved: [0; 55],
         }
     }
     /// Set the serial NOR page size
@@ -86,7 +86,7 @@ impl ConfigurationBlock {
         mut self,
         serial_clock_frequency: SerialClockFrequency,
     ) -> Self {
-        self.ip_cmd_serial_clk_freq = serial_clock_frequency as u32;
+        self.ip_cmd_serial_clk_freq = serial_clock_frequency;
         self
     }
 }

--- a/tests/imxrt1010.rs
+++ b/tests/imxrt1010.rs
@@ -1,0 +1,33 @@
+//! Tests specific to 1010 family.
+
+#![cfg(feature = "imxrt1010")]
+
+#[test]
+fn serial_clock_frequency() {
+    use imxrt_boot_gen::flexspi::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz75 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 6);
+    assert_eq!(SerialClockFrequency::MHz120 as u32, 7);
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 8);
+}
+
+#[test]
+fn ip_serial_clock_frequency() {
+    use imxrt_boot_gen::serial_flash::nor::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::NoChange as u32, 0);
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz75 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 6);
+    // No 120MHz here...
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 7);
+}

--- a/tests/imxrt1060.rs
+++ b/tests/imxrt1060.rs
@@ -1,0 +1,35 @@
+//! Tests specific to 1060 (and 1064) families.
+
+#![cfg(any(feature = "imxrt1060", feature = "imxrt1064"))]
+
+#[test]
+fn serial_clock_frequency() {
+    use imxrt_boot_gen::flexspi::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz75 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 6);
+    assert_eq!(SerialClockFrequency::MHz120 as u32, 7);
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 8);
+    assert_eq!(SerialClockFrequency::MHz166 as u32, 9);
+}
+
+#[test]
+fn ip_serial_clock_frequency() {
+    use imxrt_boot_gen::serial_flash::nor::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::NoChange as u32, 0);
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz75 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 6);
+    assert_eq!(SerialClockFrequency::MHz120 as u32, 7);
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 8);
+    assert_eq!(SerialClockFrequency::MHz166 as u32, 9);
+}

--- a/tests/imxrt1170.rs
+++ b/tests/imxrt1170.rs
@@ -1,0 +1,32 @@
+//! Tests specific to 1170 families.
+
+#![cfg(feature = "imxrt1170")]
+
+#[test]
+fn serial_clock_frequency() {
+    use imxrt_boot_gen::flexspi::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz120 as u32, 6);
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 7);
+    assert_eq!(SerialClockFrequency::MHz166 as u32, 8);
+}
+
+#[test]
+fn ip_serial_clock_frequency() {
+    use imxrt_boot_gen::serial_flash::nor::SerialClockFrequency;
+
+    assert_eq!(SerialClockFrequency::NoChange as u32, 0);
+
+    assert_eq!(SerialClockFrequency::MHz30 as u32, 1);
+    assert_eq!(SerialClockFrequency::MHz50 as u32, 2);
+    assert_eq!(SerialClockFrequency::MHz60 as u32, 3);
+    assert_eq!(SerialClockFrequency::MHz80 as u32, 4);
+    assert_eq!(SerialClockFrequency::MHz100 as u32, 5);
+    assert_eq!(SerialClockFrequency::MHz120 as u32, 6);
+    assert_eq!(SerialClockFrequency::MHz133 as u32, 7);
+}


### PR DESCRIPTION
The PR adds a feature to support FCBs on the 1170. It also adds reference FCB implementations for NXP's 1170EVK and 1010EVK. I tested both of these in imxrt-rs/imxrt-hal#121

The PR also fixes the width of a field in the serial NOR configuration block. I'll backport this to a 0.2 release.

I'm using the latest Cargo features to manage packages across the workspace. I think this in itself is a breaking change. But if it's not, the edition bump is breaking.