### PR TITLE
Adopt Rust 2024 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ packages maintained within this repository.
 
 ## [Unreleased]
 
+**BREAKING** All packages use the Rust 2024 edition.
+
 ## [0.3.4] 2025-03-01
 
 Add support for new MCUS:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "imxrt-boot-gen"
-version = "0.3.4"
-authors.workspace = true
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,10 +9,10 @@ keywords.workspace = true
 description = """
 Generate data structures for booting iMXRT processors.
 """
+resolver = "3"
 
 [workspace.package]
-authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/imxrt-rs/imxrt-boot-gen"
 categories = [

--- a/fcbs/imxrt1010evk/Cargo.toml
+++ b/fcbs/imxrt1010evk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "imxrt1010evk-fcb"
-version = "0.1.0"
-authors.workspace = true
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +9,7 @@ keywords.workspace = true
 description = "FlexSPI configuration block for NXP's IMXRT1010EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.3"
+version = "0.4.0"
 path = "../.."
 features = ["imxrt1010"]
 

--- a/fcbs/imxrt1010evk/lib.rs
+++ b/fcbs/imxrt1010evk/lib.rs
@@ -64,6 +64,9 @@ pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
         .sector_size(4096)
         .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30);
 
-#[no_mangle]
-#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+#[unsafe(no_mangle)]
+#[cfg_attr(
+    all(target_arch = "arm", target_os = "none"),
+    unsafe(link_section = ".fcb")
+)]
 pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;

--- a/fcbs/imxrt1060evk/Cargo.toml
+++ b/fcbs/imxrt1060evk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "imxrt1060evk-fcb"
-version = "0.1.0"
-authors.workspace = true
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +9,7 @@ keywords.workspace = true
 description = "FlexSPI configuration block for NXP's IMXRT1060EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.3"
+version = "0.4.0"
 path = "../.."
 features = ["imxrt1060"]
 

--- a/fcbs/imxrt1060evk/lib.rs
+++ b/fcbs/imxrt1060evk/lib.rs
@@ -63,6 +63,9 @@ pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
         .sector_size(4096)
         .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30);
 
-#[no_mangle]
-#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+#[unsafe(no_mangle)]
+#[cfg_attr(
+    all(target_arch = "arm", target_os = "none"),
+    unsafe(link_section = ".fcb")
+)]
 pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;

--- a/fcbs/imxrt1170evk/Cargo.toml
+++ b/fcbs/imxrt1170evk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "imxrt1170evk-fcb"
-version = "0.1.0"
-authors.workspace = true
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +9,7 @@ keywords.workspace = true
 description = "FlexSPI configuration block for NXP's IMXRT1170EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.3"
+version = "0.4.0"
 path = "../.."
 features = ["imxrt1170"]
 

--- a/fcbs/imxrt1170evk/lib.rs
+++ b/fcbs/imxrt1170evk/lib.rs
@@ -64,8 +64,11 @@ pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
         .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30)
         .block_size(64 * 1024);
 
-#[no_mangle]
-#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+#[unsafe(no_mangle)]
+#[cfg_attr(
+    all(target_arch = "arm", target_os = "none"),
+    unsafe(link_section = ".fcb")
+)]
 pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;
 
 #[cfg(test)]

--- a/fcbs/imxrt1180evk/Cargo.toml
+++ b/fcbs/imxrt1180evk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "imxrt1180evk-fcb"
-version = "0.1.0"
-authors.workspace = true
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +9,7 @@ keywords.workspace = true
 description = "FlexSPI configuration block for NXP's IMXRT1180EVK"
 
 [dependencies.imxrt-boot-gen]
-version = "0.3.3"
+version = "0.4.0"
 path = "../.."
 features = ["imxrt1180"]
 

--- a/fcbs/imxrt1180evk/lib.rs
+++ b/fcbs/imxrt1180evk/lib.rs
@@ -64,8 +64,11 @@ pub const SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
         .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30)
         .block_size(64 * 1024);
 
-#[no_mangle]
-#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+#[unsafe(no_mangle)]
+#[cfg_attr(
+    all(target_arch = "arm", target_os = "none"),
+    unsafe(link_section = ".fcb")
+)]
 pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock = SERIAL_NOR_CONFIGURATION_BLOCK;
 
 #[cfg(test)]

--- a/fcbs/vmu-rt1170/Cargo.toml
+++ b/fcbs/vmu-rt1170/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "vmu-rt1170-fcb"
-version = "0.1.0"
-authors.workspace = true
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,7 +9,7 @@ keywords.workspace = true
 description = "FlexSPI configuration block for NXP's VMU RT1170 Drone Control Board"
 
 [dependencies.imxrt-boot-gen]
-version = "0.3.0"
+version = "0.4.0"
 path = "../.."
 features = ["imxrt1170"]
 

--- a/fcbs/vmu-rt1170/lib.rs
+++ b/fcbs/vmu-rt1170/lib.rs
@@ -41,7 +41,10 @@ pub const BOOT_SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
         .ip_cmd_serial_clk_freq(nor::SerialClockFrequency::MHz30)
         .block_size(64 * 1024);
 
-#[no_mangle]
-#[cfg_attr(all(target_arch = "arm", target_os = "none"), link_section = ".fcb")]
+#[unsafe(no_mangle)]
+#[cfg_attr(
+    all(target_arch = "arm", target_os = "none"),
+    unsafe(link_section = ".fcb")
+)]
 pub static FLEXSPI_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
     BOOT_SERIAL_NOR_CONFIGURATION_BLOCK;

--- a/src/flexspi.rs
+++ b/src/flexspi.rs
@@ -61,7 +61,7 @@ mod sequence;
 
 pub use fields::*;
 pub use lookup::{Command, LookupTable};
-pub use sequence::{opcodes, Instr, Pads, Sequence, SequenceBuilder, JUMP_ON_CS, STOP};
+pub use sequence::{Instr, JUMP_ON_CS, Pads, STOP, Sequence, SequenceBuilder, opcodes};
 
 /// A version identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/flexspi/lookup.rs
+++ b/src/flexspi/lookup.rs
@@ -1,6 +1,6 @@
 //! FlexSPI Lookup table
 
-use super::sequence::{Sequence, SEQUENCE_SIZE};
+use super::sequence::{SEQUENCE_SIZE, Sequence};
 
 /// The default sequence definition lookup indices
 ///

--- a/src/flexspi/sequence.rs
+++ b/src/flexspi/sequence.rs
@@ -235,8 +235,8 @@ pub mod opcodes {
     /// See the documentation on the corresponding [`ssr` opcode](../sdr/index.html)
     /// for more information.
     pub mod ddr {
-        use super::sdr;
         use super::Opcode;
+        use super::sdr;
 
         /// Adds `0x20` to the opcode to make it a DDR opcode
         const fn to_ddr(opcode: Opcode) -> Opcode {
@@ -309,9 +309,9 @@ impl fmt::Debug for Opcode {
 
 #[cfg(test)]
 mod test {
-    use super::opcodes::sdr::*;
     use super::Instr;
     use super::Pads;
+    use super::opcodes::sdr::*;
     use super::{Sequence, SequenceBuilder};
 
     fn seq_to_bytes(seq: Sequence) -> Vec<u8> {

--- a/src/serial_flash/nor.rs
+++ b/src/serial_flash/nor.rs
@@ -56,8 +56,8 @@ pub enum SerialClockFrequency {
 /// # use imxrt_boot_gen::flexspi::{self, LookupTable};
 ///
 /// # const FLEXSPI_CONFIGURATION_BLOCK: flexspi::ConfigurationBlock = flexspi::ConfigurationBlock::new(LookupTable::new());
-/// #[no_mangle]
-/// #[link_section = ".serial_nor_cb"]
+/// #[unsafe(no_mangle)]
+/// #[unsafe(link_section = ".serial_nor_cb")]
 /// static SERIAL_NOR_CONFIGURATION_BLOCK: nor::ConfigurationBlock =
 ///     nor::ConfigurationBlock::new(FLEXSPI_CONFIGURATION_BLOCK)
 ///         .page_size(256)
@@ -167,7 +167,7 @@ const _STATIC_ASSERT_SIZE: [u32; 1] =
 
 #[cfg(test)]
 mod test {
-    use super::{flexspi, ConfigurationBlock, SerialClockFrequency};
+    use super::{ConfigurationBlock, SerialClockFrequency, flexspi};
     use crate::flexspi::LookupTable;
 
     #[test]


### PR DESCRIPTION
I figure we can take this breaking change now, since I'm proposing another breaking change. I think requiring the `unsafe` attributes is helpful too, although I'm skipping safety docs for the time being.